### PR TITLE
Add missing dependency on Dynlink

### DIFF
--- a/dyncompile/dune
+++ b/dyncompile/dune
@@ -5,4 +5,4 @@
 ; +warning 34: Unused type declaration.
 ; -warning 40: Constructor or label name used out of scope. (OCaml <=4.06.0)
   (flags -open Stdcompat -w +32+34-40)
-  (libraries compiler-libs stdcompat))
+  (libraries compiler-libs stdcompat dynlink))


### PR DESCRIPTION
Silences the alert proposed in ocaml/ocaml#11198, but this PR can be merged regardless.