### PR TITLE
Fix #5: compatibility with merlin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# Development version
+
+- Fix #5: compatibility with merlin
+  (reported by Kiran Gopinathan, https://github.com/thierry-martinez/metapp/issues/5)
+
 # Version 0.4.4, 2022-07-15
 
 - Port to ppxlib 0.26.0


### PR DESCRIPTION
Reported by Kiran Gopinathan,
https://github.com/thierry-martinez/metapp/issues/5

Merlin runs preprocessor in a reduced environment where `PATH` only
contains the directory where ocaml is (typically
`~/.opam/<switch>/bin`). This prevents ocaml from finding the
assembler (`as`).

This commit makes metapp check whether `as` is in the PATH before
calling ocaml. If it is not, it checks whether `/usr/bin/as` exists.
It it exists, `/usr/bin` is appended to PATH.

This is still quite fragile and will not work in environments where
`as` is not in `/usr/bin/`, but I do not know how to do better.