### PR TITLE
Native Windows support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *~
 /_build/
+/_opam/
 .merlin
 /metapp.install


### PR DESCRIPTION
1. AST files need to be written in binary mode on Windows, or else:

    File "metapp/dune", line 3, characters 14-30:
    3 |   (preprocess (pps metapp.ppx))
                      ^^^^^^^^^^^^^^^^
    (cd _build/default && .ppx/e7c203cacf1cd3bb02e6242329effa31/ppx.exe --cookie "library-name=\"metapp\"" -o metapp/metapp.pp.mli --intf metapp/metapp.mli -corrected-suffix .ppx-corrected -diff-cmd - -dump-ast)
    Fatal error: exception Failure("output_value: not a binary channel")
    Raised by primitive operation at Stdlib.output_value in file "stdlib.ml", line 386, characters 26-54
    Called from Dyncompile.write_ast in file "dyncompile/dyncompile.ml", line 82, characters 6-47
    Called from Stdlib__Fun.protect in file "fun.ml", line 33, characters 8-15
    Re-raised at Stdlib__Fun.protect in file "fun.ml", line 38, characters 6-52
    Called from Dyncompile.compile_and_load.(fun) in file "dyncompile/dyncompile.ml", line 90, characters 4-126
    Called from Stdlib__Fun.protect in file "fun.ml", line 33, characters 8-15
    Re-raised at Stdlib__Fun.protect in file "fun.ml", line 38, characters 6-52
    Called from Metapp_ppx.transform in file "ppx/metapp_ppx.ml", line 418, characters 4-101
    Called from Ppxlib__Driver.Transform.register.(fun) in file "src/driver.ml", line 190, characters 61-72
    Called from Ppxlib__Driver.apply_transforms.(fun) in file "src/driver.ml", line 574, characters 20-28
    Called from Stdlib__List.fold_left in file "list.ml", line 121, characters 24-34
    Called from Ppxlib__Driver.apply_transforms in file "src/driver.ml", line 551, characters 6-1023
    Called from Ppxlib__Driver.map_signature_gen in file "src/driver.ml", line 785, characters 4-336
    Called from Ppxlib__Driver.process_ast in file "src/driver.ml", line 1066, characters 10-127
    Called from Ppxlib__Driver.process_file in file "src/driver.ml", line 1120, characters 15-111
    Called from Ppxlib__Driver.standalone in file "src/driver.ml", line 1541, characters 9-27
    Re-raised at Location.report_exception.loop in file "parsing/location.ml", line 938, characters 14-25
    Called from Ppxlib__Driver.standalone in file "src/driver.ml", line 1544, characters 4-59
    Called from Dune__exe___ppx in file ".ppx/e7c203cacf1cd3bb02e6242329effa31/_ppx.ml-gen", line 1, characters 9-36
    File "metapp/dune", line 3, characters 14-30:

2. Dynlink.loadfile opens a temp file, and on Windows you can't delete an open file. Since the file never closes until the process dies, on Windows we let the temporary file stay on disk. The owner of the temporary directory (Dune) will erase the directory and the seemingly leaked temporary file

3. On native Windows the compiler environment does not need to be fixed. The MSVC compiler and linker should be on the PATH with INCLUDE and LIB environment variables as well when run from the Visual Studio Command Prompt or using a native Windows distribution like DkML.